### PR TITLE
Update meteofrance.class.php

### DIFF
--- a/core/class/meteofrance.class.php
+++ b/core/class/meteofrance.class.php
@@ -124,7 +124,7 @@ class meteofrance extends eqLogic {
         return;
       }
     }
-    $url = 'https://api-adresse.data.gouv.fr/search/?q=' . str_replace(' ', '-', $array['ville']) . '&postcode=' . $array['zip'] . '&limit=1';
+    $url = 'https://api-adresse.data.gouv.fr/search/?q=' . self::lowerAccent(str_replace(' ', '-', $array['ville'])) . '&postcode=' . $array['zip'] . '&limit=1';
     $return = self::callURL($url);
     log::add(__CLASS__, 'debug', 'Insee ' . print_r($return['features'][0]['properties'],true));
     $array['insee'] = $return['features'][0]['properties']['citycode'];


### PR DESCRIPTION
Fix de la requête insee si la ville a un accent (config jeedom ou geotrav), pour ne pas avoir un array "features" vide.
Cf discussion : [jeedom community](https://community.jeedom.com/t/plus-aucune-information-du-plugin-recue-a-cause-de-donnees-api-recues-incompletes/105836)