### PR TITLE
Fix class rain icons

### DIFF
--- a/core/class/meteofrance.class.php
+++ b/core/class/meteofrance.class.php
@@ -1617,7 +1617,7 @@ log::add(__CLASS__, 'debug', "  Command creation: " .$command['name']);
       $text = $this->getCmd(null,'Raindesc' . $i);
       if(is_object($prev)){
         $val = $prev->execCmd();
-        $imgDef = '<img style="width:30px;height:30px" src="/plugins/meteofrance/data/icones/Rain'.$val.'.svg"></img>';
+        $imgDef = '<img style="width:30px;height:30px" src="plugins/meteofrance/data/icones/Rain'.$val.'.svg"></img>';
         $replace['#prev' . $i . '#'] = $val;
         $replace['#prev' . $i . 'Color#'] = $color[(is_numeric($val)?$val:0)];
         $replace['#prev' . $i . 'Text#'] = $text->execCmd();


### PR DESCRIPTION
Patch for Jeedom not installed at / but for exemple in /jeedom/ folder, so the rain icons will work with relative path.